### PR TITLE
Local logger

### DIFF
--- a/d3graph/__init__.py
+++ b/d3graph/__init__.py
@@ -14,7 +14,7 @@ from d3graph.d3graph import (
 
 __author__ = 'Erdogan Tasksen'
 __email__ = 'erdogant@gmail.com'
-__version__ = '2.4.17'
+__version__ = '2.5.1'
 
 
 # module level doc-string

--- a/d3graph/d3graph.py
+++ b/d3graph/d3graph.py
@@ -25,14 +25,13 @@ from jinja2 import Environment, PackageLoader
 from packaging import version
 import datazets as dz
 
-logger = logging.getLogger('')
+logger = logging.getLogger(__name__)
 for handler in logger.handlers[:]:
     logger.removeHandler(handler)
 console = logging.StreamHandler()
 formatter = logging.Formatter('[d3graph] %(levelname)s> %(message)s')
 console.setFormatter(formatter)
 logger.addHandler(console)
-logger = logging.getLogger(__name__)
 
 
 # %%


### PR DESCRIPTION
All handlers are removed from the root logger and replace by a handler which logs with "[d3graph]" prefix. This causes that this prefix appears in logs from other modules. It also interferes with pytest log handles.
    This PR performs the handler replacement only for the local logger.
